### PR TITLE
Exemplarise software's role in error discovery

### DIFF
--- a/reproducibility.bib
+++ b/reproducibility.bib
@@ -1,2 +1,13 @@
 %% reproducibility.bib
 %% References to work showing reproducibility (or not) in particular areas
+
+@letter{Hooft_Errors_1996,
+  langid = {english},
+  title = {Errors in Protein Structures},
+  url = {https://www.nature.com/articles/381272a0},
+  type = {Comments and Opinion},
+  urldate = {2018-06-15},
+  date = {1996-05-23},
+  author = {Hooft, Rob W. W. and Vriend, Gert and Sander, Chris and Abola, Enrique E.},
+  doi = {10.1038/381272a0}
+}


### PR DESCRIPTION
Hi!

Hope this suggestion fits. Not an example of faulty software _causing_ scientific errors, like in the [introductions of @npch's talks](https://figshare.com/authors/Neil_Chue_Hong/96503), but how it helped spot them and become a part of quality-control in a repository's upload process.

I _heard_ that before this, during a rush to crystallise any protein & publish the structure, you couldn't really trust those data. _If true_, one could learn from this that sometimes, pointing the finger at almost an entire field of research, and sharing the software to prove & correct the errors may guide one throughout the ensuing controversy.
